### PR TITLE
Determine which response handler to use by calculating the distance between return types and supported response types.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.cs text eol=lf
+*.csproj text eol=lf
+*.sln text eol=lf
+*.xml text eol=lf
+*.html text eol=lf

--- a/src/Routable/Extensions.cs
+++ b/src/Routable/Extensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Routable
+{
+	internal static class Extensions
+	{
+		public static int DistanceToType(this Type @this, Type target)
+		{
+			var targetTypeInfo = target.GetTypeInfo();
+			var current = @this;
+			var currentTypeInfo = current.GetTypeInfo();
+			var root = current;
+			var rootTypeInfo = currentTypeInfo;
+			int distance = 0;
+
+			while(current != null && (targetTypeInfo.IsInterface ? currentTypeInfo.ImplementedInterfaces.Contains(target) : current != target)) {
+				root = current;
+				rootTypeInfo = currentTypeInfo;
+
+				current = currentTypeInfo.BaseType;
+				currentTypeInfo = current?.GetTypeInfo();
+
+				distance++;
+			}
+
+			if(current == null) {
+				return -1;
+			} else if(targetTypeInfo.IsInterface == false) {
+				return distance;
+			}
+
+			distance--;
+			var interfaces = rootTypeInfo.ImplementedInterfaces;
+			while(interfaces.Contains(target)) {
+				distance++;
+				interfaces = interfaces.SelectMany(i => i.GetTypeInfo().ImplementedInterfaces).ToArray();
+			}
+
+			return distance;
+		}
+		public static int DistanceToType<T>(this Type @this) => @this.DistanceToType(typeof(T));
+	}
+}

--- a/src/Routable/ResponseTypeHandlerCollection.cs
+++ b/src/Routable/ResponseTypeHandlerCollection.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Routable
+{
+	public sealed class ResponseTypeHandlerCollection<TContext, TRequest, TResponse> : IEnumerable<KeyValuePair<Type, ResponseTypeHandler<TContext, TRequest, TResponse>>>
+		where TContext : RoutableContext<TContext, TRequest, TResponse>
+		where TRequest : RoutableRequest<TContext, TRequest, TResponse>
+		where TResponse : RoutableResponse<TContext, TRequest, TResponse>
+	{
+		private IDictionary<Type, ResponseTypeHandler<TContext, TRequest, TResponse>> Collection = new Dictionary<Type, ResponseTypeHandler<TContext, TRequest, TResponse>>();
+		private IDictionary<Type, IDictionary<Type, int>> Distances = new Dictionary<Type, IDictionary<Type, int>>();
+
+		public IEnumerator<KeyValuePair<Type, ResponseTypeHandler<TContext, TRequest, TResponse>>> GetEnumerator() => Collection.GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public void Add(Type type, ResponseTypeHandler<TContext, TRequest, TResponse> handler)
+		{
+			lock(this) {
+				Collection[type] = handler;
+				foreach(var pair in Distances) {
+					if(pair.Value.ContainsKey(type) == false) {
+						var dist = pair.Key.DistanceToType(type);
+						if(dist >= 0) {
+							pair.Value.Add(type, dist);
+						}
+					}
+				}
+			}
+		}
+		public bool TryGetHandler(Type inputType, out ResponseTypeHandler<TContext, TRequest, TResponse> handler)
+		{
+			lock(this) {
+				if(Distances.TryGetValue(inputType, out var dict) == true) {
+					var handleAsType = dict.OrderByDescending(pair => pair.Value).Select(pair => pair.Key);
+					if(handleAsType == null || handleAsType.Any() == false) {
+						throw new UnhandledResponseTypeException(inputType);
+					}
+					if(Collection.TryGetValue(handleAsType.First(), out handler) == false) {
+						throw new UnhandledResponseTypeException(inputType);
+					}
+					return true;
+				} else {
+					dict = new Dictionary<Type, int>();
+					Distances.Add(inputType, dict);
+
+					Tuple<int, Type> closest = null;
+					foreach(var targetType in Collection.Keys) {
+						var dist = inputType.DistanceToType(targetType);
+						if(dist >= 0) {
+							dict.Add(targetType, dist);
+							if(closest == null || closest.Item1 > dist) {
+								closest = Tuple.Create(dist, targetType);
+							}
+						}
+					}
+
+					if(closest != null) {
+						handler = Collection[closest.Item2];
+						return true;
+					}
+
+					handler = null;
+					return false;
+				}
+			}
+		}
+	}
+}

--- a/src/Routable/RoutableOptions.cs
+++ b/src/Routable/RoutableOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -29,7 +29,7 @@ namespace Routable
 		/// <summary>
 		/// Handlers for responses of various types.
 		/// </summary>
-		public virtual IDictionary<Type, ResponseTypeHandler<TContext, TRequest, TResponse>> ResponseTypeHandlers { get; } = new Dictionary<Type, ResponseTypeHandler<TContext, TRequest, TResponse>>();
+		public virtual ResponseTypeHandlerCollection<TContext, TRequest, TResponse> ResponseTypeHandlers { get; } = new ResponseTypeHandlerCollection<TContext, TRequest, TResponse>();
 		/// <summary>
 		/// Handles empty responses.
 		/// </summary>
@@ -131,6 +131,7 @@ namespace Routable
 		public void ClearMimeTypes() => MimeTypes.Clear();
 		private void AddDefaultResponseTypeHandlers()
 		{
+			ResponseTypeHandlers.Add(typeof(object), DefaultResponseTypeHandlers.StringResponseTypeHandler);
 			ResponseTypeHandlers.Add(typeof(string), DefaultResponseTypeHandlers.StringResponseTypeHandler);
 			ResponseTypeHandlers.Add(typeof(byte[]), DefaultResponseTypeHandlers.ByteArrayResponseTypeHandler);
 		}

--- a/src/Routable/RoutableResponse.cs
+++ b/src/Routable/RoutableResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -64,10 +64,14 @@ namespace Routable
 			if(value == null) {
 				return Context.Options.EmptyResponseHandler(Context, null);
 			} else {
-				// TODO: add means of calculating type distance and caching the results.
-				if(Context.Options.ResponseTypeHandlers.TryGetValue(typeof(T), out var handler) == false && Context.Options.ResponseTypeHandlers.TryGetValue(typeof(string), out handler) == false) {
-					// TODO: add logging.
-					return Context.Options.EmptyResponseHandler(Context, null);
+				if(Context.Options.ResponseTypeHandlers.TryGetHandler(typeof(T), out var handler) == false) {
+					if(Context.Options.DefaultResponseHandler != null) {
+						handler = Context.Options.DefaultResponseHandler;
+					} else if(Context.Options.EmptyResponseHandler != null) {
+						handler = Context.Options.EmptyResponseHandler;
+					} else {
+						throw new UnhandledResponseTypeException(typeof(T));
+					}
 				}
 
 				return handler(Context, value);

--- a/src/samples/KestrelSample/MyRouting.cs
+++ b/src/samples/KestrelSample/MyRouting.cs
@@ -4,34 +4,36 @@ using Newtonsoft.Json.Linq;
 using Routable;
 using Routable.Kestrel;
 using Routable.Views.Simple;
+using System;
 
 namespace RoutableTest
 {
 	public sealed class MyRouting : KestrelRouting
 	{
-			public MyRouting(RoutableOptions<KestrelRoutableContext, KestrelRoutableRequest, KestrelRoutableResponse> options) : base(options)
-			{
-				// write a view using Routable.Views.Simple.
-				Add(_ => _.Get("/").Do(async (ctx, req, resp) => await resp.WriteViewAsync("index", new {
-					SomeModelField = "Widget widget"
-				})));
+		public MyRouting(RoutableOptions<KestrelRoutableContext, KestrelRoutableRequest, KestrelRoutableResponse> options) : base(options)
+		{
+			// write a view using Routable.Views.Simple.
+			Add(_ => _.Get("/").Do(async (ctx, req, resp) => await resp.WriteViewAsync("index", new {
+				SomeModelField = "Widget widget"
+			})));
 
-				Add(_ => _.Get("/test").Do(async (ctx, req, resp) => await resp.WriteAsync("Hello World!")));
-				Add(_ => _.Post("/test").Try(OnTestPost));
+			Add(_ => _.Get("/test").Do(async (ctx, req, resp) => await resp.WriteAsync("Hello World!")));
+			Add(_ => _.Post("/test").Try(OnTestPost));
 
-				Add(_ => _.Get("/json").Do(async (ctx, req, resp) => await resp.WriteAsync(JObject.FromObject(new {
-					Field1 = 1,
-					Field2 = "string?"
-				}))));
+			Add(_ => _.Get("/json").Do(async (ctx, req, resp) => await resp.WriteAsync(JObject.FromObject(new {
+				Field1 = 1,
+				Field2 = "string?"
+			}))));
+		}
+
+		private async Task<bool> OnTestPost(KestrelRoutableContext ctx, KestrelRoutableRequest req, KestrelRoutableResponse resp)
+		{
+			if(req.Form.TryGetValue("my-parameter", out var value) == true) {
+				await resp.WriteAsync($"Value: {value.FirstOrDefault() ?? "<null>"}");
+				return true;
+			} else {
+				return false;
 			}
-			
-			private async Task<bool> OnTestPost(KestrelRoutableContext ctx, KestrelRoutableRequest req, KestrelRoutableResponse resp) {
-				if(req.Form.TryGetValue("my-parameter", out var value) == true) {
-					await resp.WriteAsync($"Value: {value.FirstOrDefault() ?? "<null>"}");
-					return true;
-				} else {
-					return false;
-				}
-			}
+		}
 	}
 }


### PR DESCRIPTION
The response type with the lowest distance will be chosen. For example, when using string with two handlers (string, object); we would select string, not object.