### PR TITLE
RenderContext no longer crashes when the model is not provided.

### DIFF
--- a/src/Routable.Views.Simple/RenderContext.cs
+++ b/src/Routable.Views.Simple/RenderContext.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -13,7 +13,7 @@ namespace Routable.Views.Simple
 		protected SimpleViewOptions<TContext, TRequest, TResponse> ViewOptions { get; private set; }
 
 		private Stack<object> ModelStack = new Stack<object>();
-		public object Model => ModelStack.Peek();
+		public object Model => ModelStack.Any() ? ModelStack.Peek() : null;
 		private Dictionary<object, IDictionary<string, object>> Cache = new Dictionary<object, IDictionary<string, object>>();
 
 		public RenderContext(RoutableOptions<TContext, TRequest, TResponse> options, SimpleViewOptions<TContext, TRequest, TResponse> viewOptions)
@@ -27,7 +27,7 @@ namespace Routable.Views.Simple
 		private bool TryHitCache(object model, string expression, out object value)
 		{
 			lock(Cache) {
-				if(Cache.ContainsKey(model) == false) {
+				if(model == null || Cache.ContainsKey(model) == false) {
 					value = null;
 					return false;
 				}
@@ -63,7 +63,7 @@ namespace Routable.Views.Simple
 			return false;
 		}
 		public bool TryGetValue(string expression, bool onlyUseModel, out object value) => TryGetValue(Model, expression, onlyUseModel, out value);
-		public bool TryGetRootValue(string expression, bool onlyUseModel, out object value) => TryGetValue(ModelStack.Last(), expression, onlyUseModel, out value);
+		public bool TryGetRootValue(string expression, bool onlyUseModel, out object value) => TryGetValue(ModelStack.LastOrDefault(), expression, onlyUseModel, out value);
 		private bool TryGetModelValue(object model, IEnumerable<string> fields, out object value)
 		{
 			var current = model;

--- a/src/Routable/Route.cs
+++ b/src/Routable/Route.cs
@@ -1,4 +1,4 @@
-using Routable.Patterns;
+﻿using Routable.Patterns;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,6 +49,7 @@ namespace Routable
 		public Route<TContext, TRequest, TResponse> Do(Func<TContext, TRequest, TResponse, Task> action) => Do((BasicRouteAction<TContext, TRequest, TResponse>)action);
 		public Route<TContext, TRequest, TResponse> Try(Func<TContext, TRequest, TResponse, Task<bool>> action) => Do((BasicRouteAction<TContext, TRequest, TResponse>)action);
 		public Route<TContext, TRequest, TResponse> Nest(Func<TContext, TRequest, TResponse, Task<Routing<TContext, TRequest, TResponse>>> action) => Do((NestedRouteAction<TContext, TRequest, TResponse>)action);
+		public Route<TContext, TRequest, TResponse> Nest(Func<TContext, TRequest, TResponse, Routing<TContext, TRequest, TResponse>> action) => Do((NestedRouteAction<TContext, TRequest, TResponse>)action);
 
 		/// <summary>
 		/// Restrict a route to a given pattern.

--- a/src/samples/KestrelSample/KestrelSample.csproj
+++ b/src/samples/KestrelSample/KestrelSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -7,6 +7,7 @@
     <None Remove="embedded-views\embed.html" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="embedded-views\test\head.html" />
     <EmbeddedResource Include="embedded-views\test\embed.html" />
   </ItemGroup>
 	<ItemGroup>

--- a/src/samples/KestrelSample/MyRouting.cs
+++ b/src/samples/KestrelSample/MyRouting.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Routable;
@@ -22,6 +22,7 @@ namespace RoutableTest
 				},
 				People = people
 			})));
+			Add(_ => _.Get("/no-model").Do(async (ctx, req, resp) => await resp.WriteViewAsync("index")));
 
 			// write an embedded view
 			Add(_ => _.Get("/embedded").Do(async (ctx, req, resp) => await resp.WriteViewAsync("test/embed", new {

--- a/src/samples/KestrelSample/Startup.cs
+++ b/src/samples/KestrelSample/Startup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -44,7 +44,7 @@ namespace RoutableTest
 				_ => _.Get("/meeseeks").Do(async (ctx, req, resp) => await resp.WriteAsync("Hi, I'm Mr. Meeseeks!")),
 				_ => _.Path("/grimey").Do(async (ctx, req, resp) => await resp.WriteAsync("I don't check methods, because I'm Homer Simpson!")),
 				// demo: show off nested routing... for the curious, no - there is no limit.
-				_ => _.Path(new Regex("/nest(?<myParameter>.*)")).Nest(async (_ctx, _req, _resp) => {
+				_ => _.Path(new Regex("/nest(?<myParameter>.*)")).Nest((_ctx, _req, _resp) => {
 					var routing = new KestrelRouting(options) {
 						// demo: toss in a cheeky little static route.
 						builder => builder.Get("/nest/always").Do(async (ctx, req, resp) => await resp.WriteAsync("This route is always here for you"))

--- a/src/samples/KestrelSample/embedded-views/test/head.html
+++ b/src/samples/KestrelSample/embedded-views/test/head.html
@@ -1,0 +1,4 @@
+﻿<title>Routable Sample</title>
+@IfSet(Alert)
+<script>alert("@Model.Alert");</script>
+@EndIfSet

--- a/src/samples/KestrelSample/views/index.html
+++ b/src/samples/KestrelSample/views/index.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
 	<title>Sample</title>
+	@Include(test/head)
 </head>
 <body>
 	<h1>Here, we'll display a value in a paragraph if another is set.</h1>
@@ -12,11 +13,13 @@
 	<h1>Let's include another view...</h1>
 	@Include(test/embed)
 
+	@IfSet(People)
 	<h1>Here we'll iterate over a list of people.</h1>
 	<ul>
 		@ForEach(People)
 		<li><strong>@Model.Name</strong>, let me just say... <i>@Root.SomeModelField.Nested</i></li>
 		@EndForEach
 	</ul>
+	@EndIfset
 </body>
 </html>


### PR DESCRIPTION
Closes #31