### PR TITLE
Abstract attributes

### DIFF
--- a/src/Routable.Json/JsonResponseTypeHandler.cs
+++ b/src/Routable.Json/JsonResponseTypeHandler.cs
@@ -15,7 +15,7 @@ namespace Routable.Json
 			where TRequest : RoutableRequest<TContext, TRequest, TResponse>
 			where TResponse : RoutableResponse<TContext, TRequest, TResponse>
 		{
-			context.Response.Attributes.ContentType = "application/json";
+			context.Response.Abstract.ContentType = "application/json";
 
 			if(value == null) {
 				context.Response.Write("");

--- a/src/Routable.Json/Routable.Json.csproj
+++ b/src/Routable.Json/Routable.Json.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageIconUrl>http://www.hardenedelements.com/images/he-icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/HardenedElements/routable</PackageProjectUrl>
     <PackageLicenseUrl>https://www.hardenedelements.com/licenses/MIT-2017.txt</PackageLicenseUrl>

--- a/src/Routable.Json/Routable.Json.csproj
+++ b/src/Routable.Json/Routable.Json.csproj
@@ -11,7 +11,7 @@
     <Description>Add JSON support to your Routable project</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/Routable.Kestrel/KestrelRoutableResponse.cs
+++ b/src/Routable.Kestrel/KestrelRoutableResponse.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Routable.Kestrel
 {
-	public class KestrelResponseAttributes : AbstractResponseAttributes
+	public class KestrelResponseAbstractAttributes : AbstractResponseAttributes
 	{
 		private KestrelRoutableResponse Response;
 
@@ -32,7 +32,7 @@ namespace Routable.Kestrel
 			Response.Headers.Add(name, new Microsoft.Extensions.Primitives.StringValues(value));
 		}
 
-		internal KestrelResponseAttributes(KestrelRoutableResponse response) => Response = response;
+		internal KestrelResponseAbstractAttributes(KestrelRoutableResponse response) => Response = response;
 	}
 	public class KestrelRoutableResponse : RoutableResponse<
 		KestrelRoutableContext,
@@ -46,8 +46,8 @@ namespace Routable.Kestrel
 		Stream>
 	{
 		public Microsoft.AspNetCore.Http.HttpResponse PlatformResponse => Context.PlatformContext.Response;
-		private AbstractResponseAttributes _Attributes;
-		public override AbstractResponseAttributes Attributes => _Attributes;
+		private AbstractResponseAttributes _Abstract;
+		public override AbstractResponseAttributes Abstract => _Abstract;
 		public override int Status { get => PlatformResponse.StatusCode; set => PlatformResponse.StatusCode = value; }
 		public override string Reason { get => throw new NotSupportedException(); set => new NotSupportedException(); }
 		public override Microsoft.AspNetCore.Http.IResponseCookies Cookies { get => PlatformResponse.Cookies; set => throw new NotSupportedException(); }
@@ -58,7 +58,7 @@ namespace Routable.Kestrel
 
 		internal KestrelRoutableResponse(KestrelRoutableContext context) : base(context)
 		{
-			_Attributes = new KestrelResponseAttributes(this);
+			_Abstract = new KestrelResponseAbstractAttributes(this);
 		}
 
 		public override Task Redirect(string location)

--- a/src/Routable.Kestrel/Routable.Kestrel.csproj
+++ b/src/Routable.Kestrel/Routable.Kestrel.csproj
@@ -11,7 +11,7 @@
     <Description>Use Routable with the Kestrel HTTP server</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Routable\Routable.csproj" />

--- a/src/Routable.Views.Simple/Routable.Views.Simple.csproj
+++ b/src/Routable.Views.Simple/Routable.Views.Simple.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageIconUrl>http://www.hardenedelements.com/images/he-icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/HardenedElements/routable</PackageProjectUrl>
     <PackageLicenseUrl>https://www.hardenedelements.com/licenses/MIT-2017.txt</PackageLicenseUrl>

--- a/src/Routable.Views.Simple/Routable.Views.Simple.csproj
+++ b/src/Routable.Views.Simple/Routable.Views.Simple.csproj
@@ -11,7 +11,7 @@
     <Description>Use Routable with simple model-view support</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sprache" Version="2.1.0" />

--- a/src/Routable.Views.Simple/SimpleViewExtensions.cs
+++ b/src/Routable.Views.Simple/SimpleViewExtensions.cs
@@ -66,7 +66,7 @@ namespace Routable.Views.Simple
 		{
 			var view = await Template<TContext, TRequest, TResponse>.Find(@this.Context.Options, name);
 			@this.Write(async (context, stream) => {
-				context.Response.Attributes.ContentType = view.MimeType;
+				context.Response.Abstract.ContentType = view.MimeType;
 				using(var writer = new StreamWriter(stream, context.Options.StringEncoding)) {
 					await view.TryRender(name, writer, model);
 				}

--- a/src/Routable/DefaultResponseTypeHandlers.cs
+++ b/src/Routable/DefaultResponseTypeHandlers.cs
@@ -21,11 +21,11 @@ namespace Routable
 		{
 			var bytes = value as byte[] ?? new byte[] { };
 			if(bytes.Length == 0) {
-				context.Response.Attributes.ContentLength = 0;
+				context.Response.Abstract.ContentLength = 0;
 				return;
 			}
 
-			context.Response.Attributes.ContentLength = bytes.Length;
+			context.Response.Abstract.ContentLength = bytes.Length;
 			context.Response.Write(async (ctx, stream) => await stream.WriteAsync(bytes, 0, bytes.Length));
 		}
 		public static void StringResponseTypeHandler<TContext, TRequest, TResponse>(RoutableContext<TContext, TRequest, TResponse> context, object value)
@@ -35,11 +35,11 @@ namespace Routable
 		{
 			var bytes = value == null ? new byte[] { } : context.Options.StringEncoding.GetBytes(value is string ? (string)value : value.ToString());
 			if(bytes.Length == 0) {
-				context.Response.Attributes.ContentLength = 0;
+				context.Response.Abstract.ContentLength = 0;
 				return;
 			}
 
-			context.Response.Attributes.ContentLength = bytes.Length;
+			context.Response.Abstract.ContentLength = bytes.Length;
 			context.Response.Write(async (ctx, stream) => await stream.WriteAsync(bytes, 0, bytes.Length));
 		}
 	}

--- a/src/Routable/Patterns/MethodPattern.cs
+++ b/src/Routable/Patterns/MethodPattern.cs
@@ -13,6 +13,6 @@ namespace Routable.Patterns
 
 		public MethodPattern(string method) => Method = method?.ToUpper();
 
-		public override bool IsMatch(TContext context) => context.Request.Attributes.Method?.ToUpper() == Method;
+		public override bool IsMatch(TContext context) => context.Request.Abstract.Method?.ToUpper() == Method;
 	}
 }

--- a/src/Routable/Routable.csproj
+++ b/src/Routable/Routable.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageIconUrl>http://www.hardenedelements.com/images/he-icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/HardenedElements/routable</PackageProjectUrl>
     <PackageLicenseUrl>https://www.hardenedelements.com/licenses/MIT-2017.txt</PackageLicenseUrl>

--- a/src/Routable/Routable.csproj
+++ b/src/Routable/Routable.csproj
@@ -11,6 +11,6 @@
     <Description>Routable is a simple, easy to use, request routing library. It is platform agnostic and designed to easily integrate with whatever platform you prefer.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
   </PropertyGroup>
 </Project>

--- a/src/Routable/RoutableContext.cs
+++ b/src/Routable/RoutableContext.cs
@@ -2,11 +2,27 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
 using System.Text;
 using System.Threading;
 
 namespace Routable
 {
+	public abstract class AbstractContextAttributes
+	{
+		/// <summary>
+		/// Retrieve a named item associated with this request.
+		/// </summary>
+		public abstract bool TryGetPerRequestItem(string name, out object value);
+		/// <summary>
+		/// Set a per request item, regardless of the platform.
+		/// </summary>
+		public abstract void SetPerRequestItem(string name, object value);
+		/// <summary>
+		/// Remove a per request item, regardless of the platform.
+		/// </summary>
+		public abstract void RemovePerRequestItem(string name);
+	}
 	public abstract class RoutableContext<TContext, TRequest, TResponse>
 		where TContext : RoutableContext<TContext, TRequest, TResponse>
 		where TRequest : RoutableRequest<TContext, TRequest, TResponse>
@@ -41,9 +57,18 @@ namespace Routable
 		/// </summary>
 		public abstract TResponse Response { get; }
 		/// <summary>
+		/// Platform agnostic access to response attributes
+		/// </summary>
+		public abstract AbstractContextAttributes Abstract { get; }
+		/// <summary>
 		/// If an exception was thrown while processing this request, this value will be set.
 		/// </summary>
 		public Exception Error { get; internal set; }
+		/// <summary>
+		/// Principal associated with this request.
+		/// </summary>
+		/// <remarks>Platforms that do not use IPrincipal are not supported by this field. On many platforms this will be equal to User</remarks>
+		public abstract IPrincipal Principal { get; set; }
 
 		private CancellationToken _CancellationToken = CancellationToken.None;
 		/// <summary>
@@ -61,13 +86,13 @@ namespace Routable
 		/// </summary>
 		public virtual TPlatformContext PlatformContext => throw new NotSupportedException();
 		/// <summary>
-		/// Platform specific user representation for this request.
-		/// </summary>
-		public virtual TUser User { get; set; }
-		/// <summary>
 		/// Temporary variables specific to this request.
 		/// </summary>
 		public abstract TPerRequestItems PerRequestItems { get; }
+		/// <summary>
+		/// Platform specific user representation for this request.
+		/// </summary>
+		public abstract TUser User { get; set; }
 
 		protected RoutableContext(RoutableOptions<TContext, TRequest, TResponse> options) => Options = options;
 	}

--- a/src/Routable/RoutableRequest.cs
+++ b/src/Routable/RoutableRequest.cs
@@ -32,6 +32,20 @@ namespace Routable
 		/// </summary>
 		public abstract bool TryGetCookie(string name, out string value);
 		/// <summary>
+		/// Get a form parameter value, regardless of the platform.
+		/// </summary>
+		/// <param name="name">The name of the form parameter</param>
+		/// <param name="value">The value of the parameter if available</param>
+		/// <exception cref="NotSupportedException">Indicates the platform does not support this primitive</exception>
+		public abstract bool TryGetForm(string name, out IEnumerable<string> value);
+		/// <summary>
+		/// Get a query parameter value, regardless of the platform.
+		/// </summary>
+		/// <param name="name">The name of the query parameter</param>
+		/// <param name="value">The value of the parameter if available</param>
+		/// <exception cref="NotSupportedException">Indicates the platform does not support this primitive</exception>
+		public abstract bool TryGetQuery(string name, out IEnumerable<string> value);
+		/// <summary>
 		/// Get the body of the request as a string.
 		/// </summary>
 		/// <param name="encoding">Default is UTF-8</param>
@@ -62,9 +76,9 @@ namespace Routable
 		/// </summary>
 		public virtual IReadOnlyDictionary<string, object> Parameters => (IReadOnlyDictionary<string, object>)_Parameters;
 		/// <summary>
-		/// Platform agnostic response attributes
+		/// Platform agnostic access to request attributes
 		/// </summary>
-		public abstract AbstractRequestAttributes Attributes { get; }
+		public abstract AbstractRequestAttributes Abstract { get; }
 
 		protected RoutableRequest(TContext context) => Context = context;
 

--- a/src/Routable/RoutableResponse.cs
+++ b/src/Routable/RoutableResponse.cs
@@ -42,9 +42,9 @@ namespace Routable
 		/// </summary>
 		public TContext Context { get; private set; }
 		/// <summary>
-		/// Platform agnostic response attributes
+		/// Platform agnostic access to response attributes
 		/// </summary>
-		public abstract AbstractResponseAttributes Attributes { get; }
+		public abstract AbstractResponseAttributes Abstract { get; }
 		private List<Func<RoutableContext<TContext, TRequest, TResponse>, Stream, Task>> ContentWriters = new List<Func<RoutableContext<TContext, TRequest, TResponse>, Stream, Task>>();
 
 		private RoutableResponse() { }

--- a/src/Routable/Route.cs
+++ b/src/Routable/Route.cs
@@ -13,10 +13,13 @@ namespace Routable
 		where TRequest : RoutableRequest<TContext, TRequest, TResponse>
 		where TResponse : RoutableResponse<TContext, TRequest, TResponse>
 	{
+		public RoutableOptions<TContext, TRequest, TResponse> RoutableOptions { get; private set; }
 		protected List<RouteAction<TContext, TRequest, TResponse>> Actions = new List<RouteAction<TContext, TRequest, TResponse>>();
 
 		private IList<RoutePattern<TContext, TRequest, TResponse>> _Patterns = new List<RoutePattern<TContext, TRequest, TResponse>>();
 		private IReadOnlyList<RoutePattern<TContext, TRequest, TResponse>> Patterns => (IReadOnlyList<RoutePattern<TContext, TRequest, TResponse>>)_Patterns;
+
+		protected internal Route(RoutableOptions<TContext, TRequest, TResponse> options) => RoutableOptions = options;
 
 		/// <summary>
 		/// Determine if a route can handle a request context.

--- a/src/Routable/RouteFactory.cs
+++ b/src/Routable/RouteFactory.cs
@@ -18,6 +18,6 @@ namespace Routable
 		/// <summary>
 		/// Creates a new route.
 		/// </summary>
-		public virtual Route<TContext, TRequest, TResponse> Create() => new Route<TContext, TRequest, TResponse>();
+		public virtual Route<TContext, TRequest, TResponse> Create(RoutableOptions<TContext, TRequest, TResponse> options) => new Route<TContext, TRequest, TResponse>(options);
 	}
 }

--- a/src/Routable/Routing.cs
+++ b/src/Routable/Routing.cs
@@ -38,7 +38,7 @@ namespace Routable
 		/// <param name="builder">An action used to construct a single route</param>
 		public void Add(Action<Route<TContext, TRequest, TResponse>> builder)
 		{
-			var route = Options.RouteFactory.Create();
+			var route = Options.RouteFactory.Create(Options);
 			builder(route);
 			_Routes.Add(route);
 		}


### PR DESCRIPTION
Added `RoutableContext.Abstract` and support for it in `Routable.Kestrel`. Changed the name of `RoutableRequest.Attributes` and `RoutableResponse.Attributes` to `Abstract`. Added `RoutableOptions Options { get; }` to `Route`.