### PR TITLE
feat: expose KestrelRoutableOptions and KestrelRoutableContext for more advanced users

### DIFF
--- a/src/Routable.Kestrel/KestrelContextAbstractAttributes.cs
+++ b/src/Routable.Kestrel/KestrelContextAbstractAttributes.cs
@@ -1,0 +1,12 @@
+﻿namespace Routable.Kestrel
+{
+	internal class KestrelContextAbstractAttributes : AbstractContextAttributes
+	{
+		private KestrelRoutableContext Context;
+		public KestrelContextAbstractAttributes(KestrelRoutableContext context) => Context = context;
+
+		public override void RemovePerRequestItem(string name) => Context.PerRequestItems.Remove(name);
+		public override void SetPerRequestItem(string name, object value) => Context.PerRequestItems[name] = value;
+		public override bool TryGetPerRequestItem(string name, out object value) => Context.PerRequestItems.TryGetValue(name, out value);
+	}
+}

--- a/src/Routable.Kestrel/KestrelRoutableContext.cs
+++ b/src/Routable.Kestrel/KestrelRoutableContext.cs
@@ -11,15 +11,6 @@ using System.Security.Principal;
 
 namespace Routable.Kestrel
 {
-	internal class KestrelContextAbstractAttributes : AbstractContextAttributes
-	{
-		private KestrelRoutableContext Context;
-		public KestrelContextAbstractAttributes(KestrelRoutableContext context) => Context = context;
-
-		public override void RemovePerRequestItem(string name) => Context.PerRequestItems.Remove(name);
-		public override void SetPerRequestItem(string name, object value) => Context.PerRequestItems[name] = value;
-		public override bool TryGetPerRequestItem(string name, out object value) => Context.PerRequestItems.TryGetValue(name, out value);
-	}
 	public class KestrelRoutableContext : RoutableContext<
 		Microsoft.AspNetCore.Http.HttpContext,
 		KestrelRoutableContext,
@@ -58,7 +49,7 @@ namespace Routable.Kestrel
 		private KestrelContextAbstractAttributes _Abstract;
 		public override AbstractContextAttributes Abstract => _Abstract;
 
-		internal KestrelRoutableContext(RoutableOptions<KestrelRoutableContext, KestrelRoutableRequest, KestrelRoutableResponse> options, Microsoft.AspNetCore.Http.HttpContext platformContext)
+		public KestrelRoutableContext(RoutableOptions<KestrelRoutableContext, KestrelRoutableRequest, KestrelRoutableResponse> options, Microsoft.AspNetCore.Http.HttpContext platformContext)
 			: base(options)
 		{
 			_PlatformContext = platformContext;

--- a/src/Routable.Kestrel/KestrelRoutableOptions.cs
+++ b/src/Routable.Kestrel/KestrelRoutableOptions.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Routable.Kestrel
 {
-	internal partial class KestrelRoutableOptions : RoutableOptions<KestrelRoutableContext, KestrelRoutableRequest, KestrelRoutableResponse>
+	public partial class KestrelRoutableOptions : RoutableOptions<KestrelRoutableContext, KestrelRoutableRequest, KestrelRoutableResponse>
 	{
 		public IServiceProvider ApplicationServices { get; private set; }
 
@@ -16,6 +16,6 @@ namespace Routable.Kestrel
 			}
 		}
 
-		internal Task<bool> Invoke(KestrelRoutableContext context) => InvokeRouting(context);
+		public Task<bool> Invoke(KestrelRoutableContext context) => InvokeRouting(context);
 	}
 }

--- a/src/Routable.Kestrel/Routable.Kestrel.csproj
+++ b/src/Routable.Kestrel/Routable.Kestrel.csproj
@@ -11,7 +11,7 @@
     <Description>Use Routable with the Kestrel HTTP server</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
This PR gives more advanced users the ability to tailor the way Routable and Kestrel interact.